### PR TITLE
Bug fixes for the /setup command

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -76,14 +76,19 @@ class General(commands.Cog):
                                              embed_links=True,
                                              attach_files=True,
                                              external_emojis=True,
-                                             add_reactions=True)
+                                             add_reactions=True),
         }
+        position = category.channels[0].position + sorted(
+            category.channels + [channel_name], key=lambda c: str(c)
+        ).index(channel_name)
+
         channel = await ctx.guild.create_text_channel(
             channel_name,
             overwrites=overwrites,
             category=category,
+            position=position,
             topic=topic,
-            reason=f"Created by the setup command of Hog Rider ({ctx.author})"
+            reason=f"Created by the setup command of Hog Rider ({ctx.author})",
         )
         # ping owner
         await channel.send(f"{owner.mention} This channel has been set up for your use in demonstrating the features "
@@ -93,7 +98,7 @@ class General(commands.Cog):
         # add the "Bots" role
         await bot.add_roles(
             ctx.guild.get_role(BOTS_ROLE_ID),
-            reason=f"Added by setup command of Hog Rider ({ctx.author})"
+            reason=f"Added by setup command of Hog Rider ({ctx.author})",
         )
 
         # sort the Bot-Demo channels alphabetically

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -1,7 +1,8 @@
 import discord
 
-from config import settings
 from discord.ext import commands
+
+from config import settings
 
 
 JUNKIES_GUILD_ID = settings['guild']['junkies']

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -4,10 +4,10 @@ from config import settings
 from discord.ext import commands
 
 
-JUNKIES_GUILD_ID = 566451504332931073
-BOT_DEMO_CATEGORY_ID = 567551986229182474
-BOTS_ROLE_ID = 567559094152724491
-USERS_ROLE_ID = 566455547394785331
+JUNKIES_GUILD_ID = settings['guild']['junkies']
+BOT_DEMO_CATEGORY_ID = settings['category']['bot_demo']
+BOTS_ROLE_ID = settings['role']['bots']
+BOT_MAKER_ROLE_ID = settings['role']['bot_maker']
 
 
 class General(commands.Cog):
@@ -68,7 +68,7 @@ class General(commands.Cog):
         overwrites = {
             ctx.guild.default_role: discord.PermissionOverwrite(read_messages=False),
             ctx.guild.get_role(BOTS_ROLE_ID): discord.PermissionOverwrite(read_messages=False),
-            ctx.guild.get_role(USERS_ROLE_ID): discord.PermissionOverwrite(read_messages=True),
+            ctx.guild.get_role(BOT_MAKER_ROLE_ID): discord.PermissionOverwrite(read_messages=True),
             bot: discord.PermissionOverwrite(read_messages=True,
                                              send_messages=True,
                                              read_message_history=True,

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -4,6 +4,12 @@ from config import settings
 from discord.ext import commands
 
 
+JUNKIES_GUILD_ID = 566451504332931073
+BOT_DEMO_CATEGORY_ID = 567551986229182474
+BOTS_ROLE_ID = 567559094152724491
+USERS_ROLE_ID = 566455547394785331
+
+
 class General(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -38,6 +44,7 @@ class General(commands.Cog):
         Sets proper permissions
         Sets the channel topic to 'Maintained by [owner]'
         Pings owner so they see the channel and can demonstrate features
+        Adds the "Bots" role to the bot.
 
         **Example:**
         /setup @bot @owner
@@ -54,11 +61,14 @@ class General(commands.Cog):
         if owner.bot:
             return await ctx.send(f"{owner.mention} appears to be a bot, but should be the bot owner. Please try "
                                   f"again with `/setup @bot @owner`.")
-        guild = self.bot.get_guild(settings['guild']['junkies'])
-        category = self.bot.get_channel(567551986229182474)
+
+        category = self.bot.get_channel(BOT_DEMO_CATEGORY_ID)
         channel_name = f"{bot.name}-demo"
         topic = f"Maintained by {owner.display_name}"
         overwrites = {
+            ctx.guild.default_role: discord.PermissionOverwrite(read_messages=False),
+            ctx.guild.get_role(BOTS_ROLE_ID): discord.PermissionOverwrite(read_messages=False),
+            ctx.guild.get_role(USERS_ROLE_ID): discord.PermissionOverwrite(read_messages=True),
             bot: discord.PermissionOverwrite(read_messages=True,
                                              send_messages=True,
                                              read_message_history=True,
@@ -68,20 +78,30 @@ class General(commands.Cog):
                                              external_emojis=True,
                                              add_reactions=True)
         }
-        channel = await guild.create_text_channel(channel_name,
-                                                  overwrites=overwrites,
-                                                  category=category,
-                                                  topic=topic,
-                                                  reason="Created by the setup command of Hog Rider")
+        channel = await ctx.guild.create_text_channel(
+            channel_name,
+            overwrites=overwrites,
+            category=category,
+            topic=topic,
+            reason=f"Created by the setup command of Hog Rider ({ctx.author})"
+        )
         # ping owner
         await channel.send(f"{owner.mention} This channel has been set up for your use in demonstrating the features "
                            f"of **{bot.name}**. Limited troubleshooting with others is acceptable, but please do not "
                            f"allow this channel to become a testing platform.  Thanks!")
-        # Sort all text channels in Bot-Demos category
-        # position = 0
-        # for ch in sorted(category.text_channels, key=lambda c: c.name):
-        #     await ch.edit(position=position)
-        #     position += 1
+
+        # add the "Bots" role
+        await bot.add_roles(
+            ctx.guild.get_role(BOTS_ROLE_ID),
+            reason=f"Added by setup command of Hog Rider ({ctx.author})"
+        )
+
+        # sort the Bot-Demo channels alphabetically
+        for index, channel in enumerate(
+            sorted(category.channels, key=lambda c: str(c)), start=category.channels[0].position
+        ):
+            if channel.position != index:
+                await channel.edit(position=index)
 
 
 def setup(bot):


### PR DESCRIPTION
- sort the bot-demo channels alphabetically
- tidy up permissions given in the new demo channel to deny bots and allow bot makers to see
- add the bots role to the bot