### PR TITLE
Add a `recreate_rules` command which recreates the rules messages in #rules

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -1,15 +1,21 @@
+import copy
 import discord
+import re
 
 from config import settings
 from discord.ext import commands
 
 JUNKIES_GUILD_ID = settings['guild']['junkies']
 BOT_DEMO_CATEGORY_ID = settings['category']['bot_demo']
+RULES_CHANNEL_ID = settings['channels']['rules']
 HOG_RIDER_ROLE_ID = settings['roles']['hog_rider']
 BOTS_ROLE_ID = settings['roles']['bots']
 DEVELOPER_ROLE_ID = settings['roles']['developer']
 ADMIN_ROLE_ID = settings['roles']['admin']
 GUEST_ROLE_ID = settings['roles']['vip_guest']
+
+SECTION_MATCH = re.compile(r'(?P<title>.+?)<a name="(?P<number>\d+|\d+.\d+)"></a>(?P<body>(.|\n)+?(?=(#{2,3}|\Z)))')
+UNDERLINE_MATCH = re.compile(r"<ins>|</ins>")
 
 
 class General(commands.Cog):
@@ -175,6 +181,78 @@ class General(commands.Cog):
         else:
             async for message in ctx.channel.history():
                 await message.delete()
+
+    @commands.command(hidden=True)
+    @commands.has_role("Admin")
+    async def recreate_rules(self, ctx):
+        """Recreate the #rules channel.
+
+        This parses the Rules/code_of_conduct.md markdown file, and sends it as a series of embeds.
+        Assumptions are made that each section is separated by <a name="x.x"></a>.
+
+        Finally, buttons are sent with links which correspond to the various messages.
+        """
+        channel = self.bot.get_channel(RULES_CHANNEL_ID)
+        await channel.purge()
+
+        with open("Rules/code_of_conduct.md", encoding="utf-8") as fp:
+            text = fp.read()
+
+        sections = SECTION_MATCH.finditer(text)
+
+        embeds = []
+        titles = []
+        for match in sections:
+            description = match.group("body")
+            # underlines, dividers, bullet points
+            description = UNDERLINE_MATCH.sub("__", description).replace("---", "").replace("-", "\u2022")
+            title = match.group("title").replace("#", "").strip()
+
+            if "." in match.group("number"):
+                colour = 0xBDDDF4  # lighter blue for sub-headings/groups
+            else:
+                colour = discord.Colour.blue()
+
+            embeds.append(discord.Embed(title=title, description=description.strip(), colour=colour))
+            titles.append(title)
+
+        messages = [await channel.send(embed=embed) for embed in embeds]
+
+        rows = []
+        buttons = []
+
+        # FIXME: Update when d.py goes to v2
+        for i, (message, title) in enumerate(zip(messages, titles)):
+            if i == 3:
+                rows.append({
+                    "type": 1,  # action row
+                    "components": copy.copy(buttons),
+                })
+                buttons.clear()
+
+            buttons.append({
+                "type": 2,  # button type
+                "label": title.replace("#", "").strip(),
+                "style": 5,  # URL
+                "url": message.jump_url,
+            })
+
+        if buttons:
+            rows.append({
+                "type": 1,  # action row
+                "components": buttons,
+            })
+
+        await self.send_buttons(channel.id, rows, "\u200b")
+
+    async def send_buttons(self, channel_id, action_rows, content):
+        # d.py v1.x doesn't support components, so just construct the payloads manually for now.
+        route = discord.http.Route('POST', '/channels/{channel_id}/messages', channel_id=channel_id)
+        payload = {
+            "components": action_rows,
+            "content": content
+        }
+        await self.bot.http.request(route, json=payload)
 
 
 def setup(bot):


### PR DESCRIPTION
This parses the Rules/code_of_conduct.md markdown file, and sends it as a series of embeds.
Assumptions are made that each section is separated by <a name="x.x"></a>.

Finally, buttons are sent with links which correspond to the various messages.

The #rules channel ID (739676154218414090) needs to be added to config.yaml before this is pushed live.